### PR TITLE
chore(bower): add bowerrc file to use the right registry

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
+    "registry": "https://registry.bower.io",
     "directory" : "./.work/bower_components/",
     "storage": {
         "packages": "./.work/bower_cache/"


### PR DESCRIPTION
## Add `.bowerrc` file to use the right registry

### Description of the Change

1b0642d — chore(bower): add bowerrc file to use the right registry

As recommended here gist.github.com/sheerun/c04d856a7a368bad2896ff0c4958cb00

/cc @jleveugle @Jisay @frenautvh @cbourgois 