### PR TITLE
build(rollup): add missing output globals for UMD format

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,5 +6,11 @@ const config = configGenerator({
 
 export default [
   config.cjs(),
-  config.umd(),
+  config.umd({
+    output: {
+      globals: {
+        angular: 'angular',
+      },
+    },
+  }),
 ];


### PR DESCRIPTION
# Add missing output globals for UMD format

## :construction_worker_man: Build

f752352 - build(rollup): add missing output globals for UMD format

## :link: Related

fix #29

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>